### PR TITLE
External Tracking Module SDK Documentation

### DIFF
--- a/docs/vrcft-sdk/_category_.json
+++ b/docs/vrcft-sdk/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "SDK",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Documentation for creating modules for VRCFaceTracking."
+  }
+}

--- a/docs/vrcft-sdk/tracking-module.mdx
+++ b/docs/vrcft-sdk/tracking-module.mdx
@@ -137,10 +137,15 @@ public class ExampleExtTrackingModule : ExtTrackingModule
         /*
         Get latest tracking data from interface and transform to VRCFaceTracking data.
 
+        Validate if your module should be updating by checking on Status:
+
+        if (Status != ModuleStatus.Active)
+            ... Execute update cycle.
+ 
         UnifiedTracking.Data.Eye.Left.Openness = ExampleTracker.LeftEye.Openness;
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawOpen] = ExampleTracker.Mouth.JawOpen;
 
-        Feel free to function out different parts of your code to keep this function readable.
+        Feel free to function out different parts of your code to keep this readable.
         */
     }
 
@@ -154,9 +159,8 @@ public class ExampleExtTrackingModule : ExtTrackingModule
 
 ## Building Project
 
-Once the tracking module is fully setup, you are able to make a binary that can then 
-be loaded by VRCFaceTracking's module system! With `VRCFaceTracking.Core` as a 
-dependency, you can make a build of you module for use in VRCFaceTracking.
+Once the tracking module is fully setup and ready to be deployed, compile your binary. 
+This binary can then be loaded by VRCFaceTracking's module system!
 
 Simply take the compiled binary and place it in `%appdata%\VRCFaceTracking\CustomLibs`, 
 VRCFaceTracking will load any external modules in alphabetical order that are included in 

--- a/docs/vrcft-sdk/tracking-module.mdx
+++ b/docs/vrcft-sdk/tracking-module.mdx
@@ -1,0 +1,171 @@
+---
+description: Detailed overview of creating VRCFaceTracking Tracking Modules. 
+---
+
+import {EditUrl} from '@site/src/components/Utils.tsx'
+
+# Tracking Module SDK
+
+***
+
+:::danger Still under construction!
+
+This reference document is still actively being worked on. 
+Changes are subject to happen discretionally.
+
+Please consider contributing by <EditUrl>editing this page!</EditUrl>
+
+:::
+
+### Summary
+
+**VRCFaceTracking** provides an external tracking module 
+SDK that allows developers to send face tracking data to 
+any **VRCFaceTracking** compatible app. Modules will send 
+data to the generalized **UnifiedTracking** interface that 
+VRCFaceTracking will use to send tracking data to applications.
+
+***
+
+### Tracking Module Overview {#ue-overview}
+
+* [Project Setup](#project-setup)
+* [Tracking Module Architecture](#tracking-module-architecture)
+* [Building Project](#building-project)
+
+## Project Setup
+
+***
+
+**VRCFaceTracking** uses **.NET 7**, a relatively 
+easy and intuitive development platform. **VRCFaceTracking** has 
+the ability to load any class library (Managed `.dll` files) built 
+on the **.NET** platform using a built-in module loader.
+
+To get started, create a new Class Library project using the 
+**.NET 7** SDK and framework. Many IDEs provide a template to 
+quickly get started with this environment.
+
+:::tip
+
+Name the project after the tracking interface being implemented to 
+VRCFaceTracking; a general naming scheme for tracking modules is along 
+the lines of `ExampleExtTrackingInterface`.
+
+:::
+
+Once the project environment is setup, include `VRCFaceTracking.Core` 
+as a dependency (this can either be a project reference by using the 
+VRCFaceTracking.Core project in your own project, or by referencing the 
+`VRCFaceTracking.Core` binary), and inherit `ExtTrackingModule` to your 
+module's main class. This will be where all the main functionality 
+of the module will be implemented.
+
+:::warning Must implement ExtTrackingModule
+
+VRCFaceTracking will at this time only load your external module 
+if the base class inherits ExtTrackingModule, otherwise it will be
+skipped. This is to ensure that developers are implementing a 
+tracking interface extension for devices to use VRCFaceTracking tracking 
+data, or otherwise.
+
+This may be changed in the future to allow different types of modules 
+to be loaded by the module loader (potentially those that can provide 
+an output for VRCFaceTracking tracking data, modify parts of VRCFaceTracking, 
+modify the UI of VRCFaceTracking, and more).
+
+:::
+
+The default architecture platform should be `Any CPU` or `x64` to build 
+for VRCFaceTracking.
+
+Your project environment should be fully setup and ready to accept your 
+tracking interface!
+
+## Tracking Module Architecture
+
+***
+
+:::tip Refer to the VRCFaceTracking API!
+
+The following API's are referenced when 
+writing a module. These are included with `VRCFaceTracking.Core`. 
+
+* [`ExtTrackingModule`](https://github.com/benaclejames/VRCFaceTracking/blob/feat/ui/VRCFaceTracking.Core/SDK/ExtTrackingModule.cs)
+* [`ModuleMetadata` (within `ExtTrackingModule`)](https://github.com/benaclejames/VRCFaceTracking/blob/feat/ui/VRCFaceTracking.Core/SDK/ModuleMetadata.cs)
+* [`UnifiedTracking`](https://github.com/benaclejames/VRCFaceTracking/blob/feat/ui/VRCFaceTracking.Core/UnifiedTracking.cs)
+* [`UnifiedExpressions`](https://github.com/benaclejames/VRCFaceTracking/blob/feat/ui/VRCFaceTracking.Core/Params/Expressions/UnifiedExpressions.cs)
+
+[**All of VRCFaceTracking is open source**](https://github.com/benaclejames/VRCFaceTracking) and is already well documented 
+with IDE contextual documentation.
+
+:::
+
+```c title="ExampleExtTrackingInterface.cs"
+public class ExampleExtTrackingModule : ExtTrackingModule
+{
+    // What your interface is able to send as tracking data.
+    public override (bool SupportsEye, bool SupportsExpression) Supported => (true, true);
+
+    // This is the first function ran by VRCFaceTracking. Make sure to completely initialize 
+    // your tracking interface or the data to be accepted by VRCFaceTracking here. This will let 
+    // VRCFaceTracking know what data is available to be sent from your tracking interface at initialization.
+    public override (bool eyeSuccess, bool expressionSuccess) Initialize(bool eyeAvailable, bool expressionAvailable)
+    {
+        var state = (eyeAvailable, expressionAvailable);
+
+        ModuleInformation.Name = "X";
+
+        // Example of an embedded image stream being referenced as a stream
+        var stream = 
+            GetType()
+            .Assembly
+            .GetManifestResourceStream("ExampleExtTrackingInterface.Assets.x-logo.png");
+
+        // Setting the stream to be referenced by VRCFaceTracking.
+        ModuleInformation.StaticImages = 
+            stream != null ? new List<Stream> { stream } : ModuleInformation.StaticImages;
+
+        //... Initializing module. Modify state tuple as needed (or use bool contexts to determine what should be initialized).
+
+        return state;
+    }
+
+    // Function that should poll data from the tracking interface.
+    public override void Update()
+    {
+        /*
+        Get latest tracking data from interface and transform to VRCFaceTracking data.
+
+        UnifiedTracking.Data.Eye.Left.Openness = ExampleTracker.LeftEye.Openness;
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawOpen] = ExampleTracker.Mouth.JawOpen;
+
+        Feel free to function out different parts of your code to keep this function readable.
+        */
+    }
+
+    // Called when the module is unloaded or VRCFaceTracking itself tears down.
+    public override void Teardown()
+    {
+        //... Deinitialize tracking interface; dispose any data created with the module.
+    }
+}
+```
+
+## Building Project
+
+Once the tracking module is fully setup, you are able to make a binary that can then 
+be loaded by VRCFaceTracking's module system! With `VRCFaceTracking.Core` as a 
+dependency, you can make a build of you module for use in VRCFaceTracking.
+
+Simply take the compiled binary and place it in `%appdata%\VRCFaceTracking\CustomLibs`, 
+VRCFaceTracking will load any external modules in alphabetical order that are included in 
+this folder.
+
+:::tip Use Build Events!
+
+Setting up build events for your project can make it easy to 
+iterate your project faster. Create a build event to place your 
+compiled binaries into the appropriate destinations!
+
+:::

--- a/versioned_docs/version-v4.0/vrcft-sdk/_category_.json
+++ b/versioned_docs/version-v4.0/vrcft-sdk/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "SDK",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Documentation for creating modules for VRCFaceTracking."
+  }
+}

--- a/versioned_docs/version-v4.0/vrcft-sdk/tracking-module.mdx
+++ b/versioned_docs/version-v4.0/vrcft-sdk/tracking-module.mdx
@@ -1,0 +1,165 @@
+---
+description: Detailed overview of creating VRCFaceTracking Tracking Modules. 
+---
+
+import {EditUrl} from '@site/src/components/Utils.tsx'
+
+
+# Tracking Module SDK
+
+***
+
+:::danger v4.0.0 SDK will be depricated soon!
+
+The documentation here references VRCFaceTracking in the `v4.0.0` 
+release state. If you want to see the latest documentation that 
+is reflective of active development, please consider using the 
+['Current' docs](docs/vrcft-sdk/tracking-module.mdx)
+
+:::
+
+### Summary
+
+**VRCFaceTracking** provides an external tracking module 
+SDK that allows developers to send face tracking data to 
+any **VRCFaceTracking** compatible app. Modules will send 
+data to the **UnifiedTrackingData** interface that 
+VRCFaceTracking will use to send tracking data to applications.
+
+***
+
+### Tracking Module Overview {#ue-overview}
+
+* [Project Setup](#project-setup)
+* [Tracking Module Architecture](#tracking-module-architecture)
+* [Building Project](#building-project)
+
+## Project Setup
+
+***
+
+**VRCFaceTracking** uses **.NET Framework**, a relatively 
+easy and intuitive development platform. **VRCFaceTracking** has 
+the ability to load any class library (Managed `.dll` files) built 
+on the **.NET Framework** platform using a built-in module loader.
+
+To get started, create a new Class Library project using the 
+**.NET Framework v4.7.2** SDK and framework. Many IDEs provide a template to 
+quickly get started with this environment.
+
+:::tip
+
+Name the project after the tracking interface being implemented to 
+VRCFaceTracking; a general naming scheme for tracking modules is along 
+the lines of `ExampleExtTrackingInterface`.
+
+:::
+
+Once the project environment is setup, include `VRCFaceTracking` 
+as a dependency (this can either be a project reference by using the 
+VRCFaceTracking project in your own project, or by referencing the 
+`VRCFaceTracking` binary), and inherit `ExtTrackingModule` to your 
+module's main class. This will be where all the main functionality 
+of the module will be implemented.
+
+:::warning Must implement ExtTrackingModule
+
+VRCFaceTracking will at this time only load your external module 
+if the base class inherits ExtTrackingModule, otherwise it will be
+skipped. This is to ensure that developers are implementing a 
+tracking interface extension for devices to use VRCFaceTracking tracking 
+data, or otherwise.
+
+This may be changed in the future to allow different types of modules 
+to be loaded by the module loader (potentially those that can provide 
+an output for VRCFaceTracking tracking data, modify parts of VRCFaceTracking, 
+modify the UI of VRCFaceTracking, and more).
+
+:::
+
+The default architecture platform should be `Any CPU` or `x86` to build 
+for VRCFaceTracking.
+
+Your project environment should be fully setup and ready to accept your 
+tracking interface!
+
+## Tracking Module Architecture
+
+***
+
+:::tip Refer to the VRCFaceTracking API!
+
+The following API's are referenced when 
+writing a module. These are included with `VRCFaceTracking`. 
+
+* [`ExtTrackingModule`](https://github.com/benaclejames/VRCFaceTracking/blob/v4.0.0/VRCFaceTracking/SDK/ExtTrackingModule.cs)
+* [`UnifiedTrackingData`](https://github.com/benaclejames/VRCFaceTracking/blob/v4.0.0/VRCFaceTracking/UnifiedTrackingData.cs)
+* [`ViveSR.anipal.Lip`](https://github.com/benaclejames/VRCFaceTracking/blob/v4.0.0/VRCFaceTracking/TrackingLibs/SRanipal/Lip/SRanipal_LipData_v2.cs#L11)
+* [`ViveSR.anipal.Eye`](https://github.com/benaclejames/VRCFaceTracking/blob/v4.0.0/VRCFaceTracking/TrackingLibs/SRanipal/Lip/SRanipal_EyeData_v2.cs)
+
+[**VRCFaceTracking v4.0.0 source code**](https://github.com/benaclejames/VRCFaceTracking/tree/v4.0.0).
+
+:::
+
+```c title="ExampleExtTrackingInterface.cs"
+public class ExampleExtTrackingModule : ExtTrackingModule
+{
+    // What your interface is able to send as tracking data.
+    public override (bool SupportsEye, bool SupportsLip) Supported => (true, true);
+
+    // This is the first function ran by VRCFaceTracking. Make sure to completely initialize 
+    // your tracking interface or the data to be accepted by VRCFaceTracking here. This will let 
+    // VRCFaceTracking know what data is available to be sent from your tracking interface at initialization.
+    public override (bool eyeSuccess, bool lipSuccess) Initialize(bool eyeAvailable, bool lipAvailable)
+    {
+        var state = (eyeAvailable, lipAvailable);
+
+        //... Initializing module. Modify state tuple as needed (or use bool contexts to determine what should be initialized).
+
+        return state;
+    }
+
+    // Function that should poll data from the tracking interface.
+    public override Action GetUpdateThreadFunc()
+    {
+        return () =>
+        {
+            while (true)
+            {
+                /*
+                Get latest tracking data from your interface and transform to VRCFaceTracking data.
+
+                UnifiedTrackingData.EyeTrackingData.Left.Openness = ExampleTracker.LeftEye.Openness;
+                UnifiedTrackingData.LipTrackingData.LatestShapes[(int)LipShape_v2.JawOpen] = ExampleTracker.Mouth.JawOpen;
+
+                Feel free to function out different parts of your code to keep this function readable.
+                */
+            }
+        };
+    }
+
+    // Called when the module is unloaded or VRCFaceTracking itself tears down.
+    public override void Teardown()
+    {
+        //... Deinitialize tracking interface; dispose any data created with the module.
+    }
+}
+```
+
+## Building Project
+
+Once the tracking module is fully setup, you are able to make a binary that can then 
+be loaded by VRCFaceTracking's module system! With `VRCFaceTracking` as a 
+dependency, you can make a build of you module for use in VRCFaceTracking.
+
+Simply take the compiled binary and place it in `%appdata%\VRCFaceTracking\CustomLibs`, 
+VRCFaceTracking will load external modules after attempting to load the integrated SRanipal 
+Tracking Module.
+
+:::tip Use Build Events!
+
+Setting up build events for your project can make it easy to 
+iterate your project faster. Create a build event to place your 
+compiled binaries into the appropriate destinations!
+
+:::

--- a/versioned_docs/version-v4.0/vrcft-sdk/tracking-module.mdx
+++ b/versioned_docs/version-v4.0/vrcft-sdk/tracking-module.mdx
@@ -132,7 +132,7 @@ public class ExampleExtTrackingModule : ExtTrackingModule
                 UnifiedTrackingData.EyeTrackingData.Left.Openness = ExampleTracker.LeftEye.Openness;
                 UnifiedTrackingData.LipTrackingData.LatestShapes[(int)LipShape_v2.JawOpen] = ExampleTracker.Mouth.JawOpen;
 
-                Feel free to function out different parts of your code to keep this function readable.
+                Feel free to function out different parts of your code to keep this readable.
                 */
             }
         };
@@ -148,13 +148,12 @@ public class ExampleExtTrackingModule : ExtTrackingModule
 
 ## Building Project
 
-Once the tracking module is fully setup, you are able to make a binary that can then 
-be loaded by VRCFaceTracking's module system! With `VRCFaceTracking` as a 
-dependency, you can make a build of you module for use in VRCFaceTracking.
+Once the tracking module is fully setup and ready to be deployed, compile your binary. 
+This binary can then be loaded by VRCFaceTracking's module system!
 
 Simply take the compiled binary and place it in `%appdata%\VRCFaceTracking\CustomLibs`, 
-VRCFaceTracking will load external modules after attempting to load the integrated SRanipal 
-Tracking Module.
+VRCFaceTracking will load any external modules in alphabetical order that are included in 
+this folder.
 
 :::tip Use Build Events!
 


### PR DESCRIPTION
This PR covers the inclusion of an easily referenceable SDK for developers to use to help create external tracking modules. Currently I have added the following additions: 

- SDK section to the Docs
   -  This will be where current and future developer-centric documentation can be contained. Currently only contains External Tracking Module, but it could be expanded to contain future modules or API's that developers can use in VRCFaceTracking. Currently pages are expected to reference directly to the VRCFaceTracking repository for API references
- External Tracking Module SDK page
   -  Covers the External Tracking Module system currently in VRCFaceTracking. Goes over the project setup, frameworks used, general architecture of the module, and tips to crash-course developers into VRCFaceTracking's ecosystem.
   - Also includes relevant information for `v4.0.0` and `Next` page contexts!
   - Code Examples!
  
![image](https://user-images.githubusercontent.com/74634856/232649650-aed5d29d-dc01-4613-b7a4-cb3b365ef5f9.png)

![image](https://user-images.githubusercontent.com/74634856/232649787-90b97849-d647-4e16-97ee-378e9a94b86c.png)
