### PR TITLE
Remove danwillm's Steam Link module from setup instructions

### DIFF
--- a/docs/hardware/quest-pro.mdx
+++ b/docs/hardware/quest-pro.mdx
@@ -325,7 +325,6 @@ Interested in the source code? Check out the [QuestProOpenXRTrackingModule sourc
     - Virtual Desktop v1.29.3 introduces support for Virtual Desktop's own OpenXR runtime VDXR. 
     **[ALXR Local module](https://github.com/korejan/VRCFT-ALXR-Modules)** *can be used* for VRCFT instead of the Virtual Desktop module if VDXR is set as the active runtime. 
 - If you are using SteamLink, you will need to use the **[SteamLink VRCFT Module](https://github.com/ykeara/LinkFT)**
-   - You can also optionally (manually build and) install danwillm's ["example" module](https://github.com/danwillm/VRCFT-SteamLink). A [zip with the compiled binary](https://cdn.discordapp.com/attachments/1179867564847943753/1180537883375960155/b146eda9-be48-4016-ab63-680a694064bd.zip?ex=657dc894&is=656b5394&hm=9581609843b0d071f5c9684e14bf126c1b0f26ec3bfc516d583cb163a3132c41&) can be found in the <CustomLink to="discord"/>. 
 
 Links are to Module source repositories, for those interested in contributing and improving the modules.
 All* modules are readily available for installation via the VRCFaceTracking built in module registry.


### PR DESCRIPTION
The module I have online is mainly meant as a reference/example for developers using Steam Link's OSC outputs - It's what I use internally for testing and so is a good reference for them as well if they are running into issues.

Ykeara's module is what should be recommended for people to use VRCFT with Steam Link for VRChat, etc.

Thanks for thinking about this though!