### PR TITLE
Specify SRaniple location for focus3_xre page

### DIFF
--- a/docs/hardware/VIVE/focus3_xre.mdx
+++ b/docs/hardware/VIVE/focus3_xre.mdx
@@ -49,7 +49,7 @@ ALXR on Vive standalone headsets may have VR streaming issues currently (January
 </details>
 
 2. Make sure that you agree to the privacy notices for eye and face tracking after installation, follow the instructions for eye tracking calibration, and have the eye and face tracking options enabled in the headset Input settings. 
-3. Install VIVE Console onto your computer. We need this for the latest version (**1.3.6.8+**) of [SRanipal](./sranipal.mdx#installing-via-vive-console) 
+3. Install VIVE Console onto your computer We need this for the latest version (**1.3.6.8+**) of [SRanipal](./sranipal.mdx#installing-via-vive-console). This can be found at `...\steamapps\common\VIVEDriver\App\SRanipal\DriverInstaller.msi`
 
 :::info
 For eye expressions (blinking) to work correctly in SRanipal over Vive Streamer streaming, [you **must** use SRanipal version greater than 1.3.6.8](https://forum.htc.com/topic/14087-vbs-pc-vr-how-to-use-facial-tracking-on-focus3/). 


### PR DESCRIPTION
Just points to the file path of the SRaniple installer in Vive Console, as it is not specified anywhere in-doc where it is.