### PR TITLE
Update the quest pro documentation.

### DIFF
--- a/docs/hardware/quest-pro.mdx
+++ b/docs/hardware/quest-pro.mdx
@@ -234,31 +234,6 @@ To let the Virtual Desktop VRCFT module properly initialize, make sure to start 
 
 </details>
 
-
-Switching to Virtual Desktop Beta (when a beta is active) may let you use yet-to-be-released features. 
-In case there is a beta you would like to try, you can switch to the beta following the instructions in the dropdown
-
-<details>
-  <summary>How To Switch to Virtual Desktop Beta</summary>
-
-  There are a few ways to change to Virtual Desktop Beta when a Beta is active. Meta constantly changes how to accomplish this so the fool-proof way is to just sideload the beta APK. 
-
-  1. Change to the Beta channel on the Virtual Desktop Meta store page (while logged into your Meta Quest account). You will need to then update the Virtual Desktop app in your headset after this change. 
-  <div style={{
-    width: '75%',
-    height: 'auto',
-    margin: 'auto',
-    display: 'block'
-  }}>
-    <img src={require("./img/quest/virtual_desktop_beta_desktop.png").default} alt="Changing to Beta on the Meta website" />
-  </div>
-
-  2. Change to the Beta channel in the Meta Quest phone app (while logged into your Meta Quest account). You will need to then update the Virtual Desktop app in your headset after this change.
-
-  3. Install the beta APK manually. Grab the beta `VirtualDesktop.Android.Quest.apk` (without the 1) from the Virtual Desktop release page and [install it with SideQuest](#using-sidequest-to-side-load-quest-apps). You will need to uninstall the live version of Virtual Desktop from your Quest first. 
-
-</details>
-
 ### SteamLink Setup
 
 <details>

--- a/docs/hardware/quest-pro.mdx
+++ b/docs/hardware/quest-pro.mdx
@@ -183,16 +183,12 @@ If this is your first time using ALXR, follow the [Usage guide](https://github.c
 
 ### ALVR Setup
 
-:::note
-Using ALVR will require you to [sideload applications to you Quest](#using-sidequest-to-side-load-quest-apps)
-:::
-
 <details>
   <summary>ALVR Setup</summary>
 
 1. [**MAKE SURE YOUR HEADSET HAS EYE AND FACE TRACKING ENABLED**](#enabling-eye-and-face-tracking-on-the-headset)
-2. Install the ALVR **Nightly** streamer on the PC and **Nightly** client on the Quest Pro if you have not already.
-Follow the [ALVR Install instructions](https://github.com/alvr-org/ALVR/wiki/Installation-guide#nightly) if this is your first time using ALVR.
+2. Install the [ALVR streamer](https://github.com/alvr-org/ALVR/releases) on the PC and [ALVR client](https://www.meta.com/en-gb/experiences/alvr/7674846229245715/) on the Quest Pro if you have not already.
+Follow the [ALVR Install instructions](https://github.com/alvr-org/ALVR/wiki/Installation-guide) if this is your first time using ALVR.
 3. Launch ALVR streamer and set `Eye and face tracking` to `VRCFaceTracking`.
 4. Start the client on the Quest Pro and connect.
 5. Install the **ALVR Module** from the VRCFaceTracking module repository.


### PR DESCRIPTION
Removes mentions of virtual desktop's beta from the "Virtual Desktop Setup" section as this was only causing additional confusion for users.

Updated the ALVR section to mention the AppLab method of installing ALVR instead of ALVR nightly as this method does not require developer mode or sideloading.