### PR TITLE
Correct erroneous EyeClosed Basis in _unified-blended-table.mdx

### DIFF
--- a/docs/tutorial-avatars/tutorial-avatars-extras/_unified-blended-table.mdx
+++ b/docs/tutorial-avatars/tutorial-avatars-extras/_unified-blended-table.mdx
@@ -15,7 +15,7 @@ import FilterTable from '@site/src/components/FilterTable.tsx'
             <img src={require("./img/avatar/avatar_ref_eyeclosed.png").default} style={{width: 192}} alt="Reference Image" />,
             'EyeClosed',
             <ContextModal src={require('./unified-explanations/eye/_eye_closed.mdx').default}>Closes both eye lids.</ContextModal>,
-            <>EyeClosedRight<br/>EyeClosedRight</>
+            <>EyeClosedRight<br/>EyeClosedLeft</>
         ],
         [
             <img src={require("./img/avatar/avatar_ref_eyewide.png").default} style={{width: 192}} alt="Reference Image" />,


### PR DESCRIPTION
Minor typo(?): EyeClosed specifies EyeClosedRight twice as a basis. It should be specifying both Right and Left.