### PR TITLE
Add instructions to modify faceTrackingMode in the Pico 4 Pro / Enterprise guide

### DIFF
--- a/docs/hardware/vr/pico/pico4pe.mdx
+++ b/docs/hardware/vr/pico/pico4pe.mdx
@@ -10,9 +10,12 @@ The Pro and Enterprise editions only differ in the available system software and
 2. Enable both Eye Tracking and Lip Tracking on Pico Settings, those can be found under LAB tab.
 3. Verify that you have Pico Connect installed on your headset. If not, you will need to get it from the Pico Store first before continuing.
 4. Install [Pico Connect](https://www.picoxr.com/global/software/pico-link) on your computer.
-5. After installing Pico Connect on your computer you should update a hidden configuration to change its facetracking to legacy protocol, 
-find the file at `C:\Users\{YourUsername}\AppData\Roaming\PICO Connect\setting.json` and change `faceTrackingTransferProtocol` to `2`. 
-This is a temporary fix; currently the Pico4SAFTExtTrackingModule does not support the newer protocol.
+5. After installing Pico Connect on your computer you should update a hidden configuration to change its facetracking to legacy protocol and Image-driven mode, 
+find the file at `C:\Users\{YourUsername}\AppData\Roaming\PICO Connect\setting.json` and change the next values: 
+- `faceTrackingTransferProtocol` to `2`. 
+- `faceTrackingMode` to `1`.
+
+This is a temporary fix; currently the Pico4SAFTExtTrackingModule does not support the newer protocol. Modifying the facetracking mode will also prevent the facetracking from stopping to work when theres microphone input.
 
 ##  Streaming Assistant Setup (Legacy)
 


### PR DESCRIPTION
Adds instructions to modify the face tracking mode in Pico Connect settings.json because the default value causes face tracking to stop working when theres microphone input. It also cannot be changed from the UI in the latest versions. Insight to this in the discord forum: https://discord.com/channels/849300336128032789/1347913796009590855